### PR TITLE
Refactor: Changes in Types and Decorators

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -1,5 +1,5 @@
 import { Server } from "bun";
-import { Handler } from "./types";
+import { Handler, Handlers } from "./types";
 import { HttpMethod } from "./utils";
 import { parse } from "fast-querystring";
 
@@ -483,7 +483,6 @@ export class Context {
     return this.req.method;
   }
 
-
   public get secure(): boolean {
     return this.req.url.startsWith("https");
   }
@@ -557,7 +556,7 @@ class Local {
 }
 
 export class Routes {
-  constructor(public handlers: Handler[], public handlerIndex: number = 0) {}
+  constructor(public handlers: Handlers, public handlerIndex: number = 0) {}
 
   public next(): void {
     if (this.hasNext()) {

--- a/src/decorators/after.ts
+++ b/src/decorators/after.ts
@@ -1,13 +1,12 @@
-import { Handler } from "../types";
+import { Handlers, FunctionTarget } from "../types";
 
 /**
  * After decorator, used to add middleware after a route handler. Middleware will be executed in order.
  * @param handlers
  *
  */
-export function After(...handlers: Handler[]) {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return function (target: any, key: string) {
+export function After(...handlers: Handlers) {
+  return function (target: FunctionTarget, key: string) {
     if (!target) return;
     if (!target[key]) return;
     if (typeof target[key] !== "function")

--- a/src/decorators/after.ts
+++ b/src/decorators/after.ts
@@ -15,7 +15,7 @@ export function After(...handlers: Handler[]) {
 
     const after = Reflect.getMetadata("after", target, key);
     if (after) {
-      handlers = [...after, ...handlers];
+      handlers = after.concat(handlers);
     }
     Reflect.defineMetadata("after", handlers, target, key);
   };

--- a/src/decorators/all.ts
+++ b/src/decorators/all.ts
@@ -1,3 +1,4 @@
+import { FunctionTarget } from "../types";
 import { HttpMethod, createPath } from "../utils";
 
 /**
@@ -10,8 +11,7 @@ export function All(path?: string) {
   if (path && typeof path !== "string")
     throw new Error("Path must be a string");
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return function (target: any, key: string) {
+  return function (target: FunctionTarget, key: string) {
     if (!target) return;
     if (!target[key]) return;
     if (typeof target[key] !== "function")

--- a/src/decorators/before.ts
+++ b/src/decorators/before.ts
@@ -15,7 +15,7 @@ export function Before(...handlers: Handler[]) {
 
     const before = Reflect.getMetadata("before", target, key);
     if (before) {
-      handlers = [...before, ...handlers];
+      handlers = before.concat(handlers);
     }
     Reflect.defineMetadata("before", handlers, target, key);
   };

--- a/src/decorators/before.ts
+++ b/src/decorators/before.ts
@@ -1,13 +1,12 @@
-import { Handler } from "../types";
+import { FunctionTarget, Handlers } from "../types";
 
 /**
  * Before decorator, used to add middleware before a route handler. Middleware will be executed in order.
  * @param handlers
  *
  */
-export function Before(...handlers: Handler[]) {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return function (target: any, key: string) {
+export function Before(...handlers: Handlers) {
+  return function (target: FunctionTarget, key: string) {
     if (!target) return;
     if (!target[key]) return;
     if (typeof target[key] !== "function")

--- a/src/decorators/controller.ts
+++ b/src/decorators/controller.ts
@@ -1,4 +1,4 @@
-import { Route } from "../types";
+import { Route, Controller } from "../types";
 
 /**
   Controller decorator is used to define a controller class.
@@ -7,8 +7,8 @@ import { Route } from "../types";
 **/
 export function Controller(prefix: string) {
   prefix = prefix.replace(/\/$/, "");
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return function (target: any) {
+
+  return function (target: Controller) {
     for (const value of Object.getOwnPropertyNames(target.prototype)) {
       const path = Reflect.getMetadata("path", target.prototype, value);
       const method = Reflect.getMetadata("method", target.prototype, value);

--- a/src/decorators/controller.ts
+++ b/src/decorators/controller.ts
@@ -1,4 +1,8 @@
-import { Route, Controller } from "../types";
+import {
+  Route,
+  Controller as ControllerType,
+  ClassConstructor,
+} from "../types";
 
 /**
   Controller decorator is used to define a controller class.
@@ -8,7 +12,7 @@ import { Route, Controller } from "../types";
 export function Controller(prefix: string) {
   prefix = prefix.replace(/\/$/, "");
 
-  return function (target: Controller) {
+  return function <T>(target: ClassConstructor<T>) {
     for (const value of Object.getOwnPropertyNames(target.prototype)) {
       const path = Reflect.getMetadata("path", target.prototype, value);
       const method = Reflect.getMetadata("method", target.prototype, value);
@@ -26,7 +30,7 @@ export function Controller(prefix: string) {
             : routePath,
           fnName: value,
           method,
-          target,
+          target: target as ControllerType,
           pathHasParams,
           before: Reflect.getMetadata("before", target.prototype, value) || [],
           after: Reflect.getMetadata("after", target.prototype, value) || [],

--- a/src/decorators/controller.ts
+++ b/src/decorators/controller.ts
@@ -6,9 +6,6 @@ import { Route } from "../types";
   @param prefix - the prefix for all routes in the controller
 **/
 export function Controller(prefix: string) {
-  if (typeof prefix !== "string")
-    throw new Error("Controller decorator can only be used on a class");
-
   prefix = prefix.replace(/\/$/, "");
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return function (target: any) {

--- a/src/decorators/delete.ts
+++ b/src/decorators/delete.ts
@@ -7,9 +7,6 @@ import { HttpMethod, createPath } from "../utils";
  *
  **/
 export function Delete(path?: string) {
-  if (path && typeof path !== "string")
-    throw new Error("Path must be a string");
-
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return function (target: any, key: string) {
     if (!target) return;

--- a/src/decorators/delete.ts
+++ b/src/decorators/delete.ts
@@ -1,3 +1,4 @@
+import { FunctionTarget } from "..";
 import { HttpMethod, createPath } from "../utils";
 
 /**
@@ -7,8 +8,7 @@ import { HttpMethod, createPath } from "../utils";
  *
  **/
 export function Delete(path?: string) {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return function (target: any, key: string) {
+  return function (target: FunctionTarget, key: string) {
     if (!target) return;
     if (!target[key]) return;
     if (typeof target[key] !== "function")

--- a/src/decorators/get.ts
+++ b/src/decorators/get.ts
@@ -1,3 +1,4 @@
+import { FunctionTarget } from "..";
 import { HttpMethod, createPath } from "../utils";
 
 /**
@@ -7,8 +8,7 @@ import { HttpMethod, createPath } from "../utils";
  *
  **/
 export function Get(path?: string) {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return function (target: any, key: string) {
+  return function (target: FunctionTarget, key: string) {
     if (!target) return;
     if (!target[key]) return;
     if (typeof target[key] !== "function")

--- a/src/decorators/get.ts
+++ b/src/decorators/get.ts
@@ -7,9 +7,6 @@ import { HttpMethod, createPath } from "../utils";
  *
  **/
 export function Get(path?: string) {
-  if (path && typeof path !== "string")
-    throw new Error("Path must be a string");
-
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return function (target: any, key: string) {
     if (!target) return;

--- a/src/decorators/head.ts
+++ b/src/decorators/head.ts
@@ -7,9 +7,6 @@ import { HttpMethod, createPath } from "../utils";
  *
  **/
 export function Head(path?: string) {
-  if (path && typeof path !== "string")
-    throw new Error("Path must be a string");
-
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return function (target: any, key: string) {
     if (!target) return;

--- a/src/decorators/head.ts
+++ b/src/decorators/head.ts
@@ -1,3 +1,4 @@
+import { FunctionTarget } from "..";
 import { HttpMethod, createPath } from "../utils";
 
 /**
@@ -7,8 +8,7 @@ import { HttpMethod, createPath } from "../utils";
  *
  **/
 export function Head(path?: string) {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return function (target: any, key: string) {
+  return function (target: FunctionTarget, key: string) {
     if (!target) return;
     if (!target[key]) return;
     if (typeof target[key] !== "function")

--- a/src/decorators/options.ts
+++ b/src/decorators/options.ts
@@ -7,9 +7,6 @@ import { HttpMethod, createPath } from "../utils";
  *
  **/
 export function Options(path?: string) {
-  if (path && typeof path !== "string")
-    throw new Error("Path must be a string");
-
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return function (target: any, key: string) {
     if (!target) return;

--- a/src/decorators/options.ts
+++ b/src/decorators/options.ts
@@ -1,3 +1,4 @@
+import { FunctionTarget } from "..";
 import { HttpMethod, createPath } from "../utils";
 
 /**
@@ -7,8 +8,7 @@ import { HttpMethod, createPath } from "../utils";
  *
  **/
 export function Options(path?: string) {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return function (target: any, key: string) {
+  return function (target: FunctionTarget, key: string) {
     if (!target) return;
     if (!target[key]) return;
     if (typeof target[key] !== "function")

--- a/src/decorators/patch.ts
+++ b/src/decorators/patch.ts
@@ -7,9 +7,6 @@ import { HttpMethod, createPath } from "../utils";
  *
  **/
 export function Patch(path?: string) {
-  if (path && typeof path !== "string")
-    throw new Error("Path must be a string");
-
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return function (target: any, key: string) {
     if (!target) return;

--- a/src/decorators/patch.ts
+++ b/src/decorators/patch.ts
@@ -1,3 +1,4 @@
+import { FunctionTarget } from "..";
 import { HttpMethod, createPath } from "../utils";
 
 /**
@@ -7,8 +8,7 @@ import { HttpMethod, createPath } from "../utils";
  *
  **/
 export function Patch(path?: string) {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return function (target: any, key: string) {
+  return function (target: FunctionTarget, key: string) {
     if (!target) return;
     if (!target[key]) return;
     if (typeof target[key] !== "function")

--- a/src/decorators/post.ts
+++ b/src/decorators/post.ts
@@ -8,9 +8,6 @@ import { HttpMethod, createPath } from "../utils";
  **/
 
 export function Post(path?: string) {
-  if (path && typeof path !== "string")
-    throw new Error("Path must be a string");
-
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return function (target: any, key: string) {
     if (!target) return;

--- a/src/decorators/post.ts
+++ b/src/decorators/post.ts
@@ -1,3 +1,4 @@
+import { FunctionTarget } from "../types";
 import { HttpMethod, createPath } from "../utils";
 
 /**
@@ -8,8 +9,7 @@ import { HttpMethod, createPath } from "../utils";
  **/
 
 export function Post(path?: string) {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return function (target: any, key: string) {
+  return function (target: FunctionTarget, key: string) {
     if (!target) return;
     if (!target[key]) return;
     if (typeof target[key] !== "function")

--- a/src/decorators/put.ts
+++ b/src/decorators/put.ts
@@ -1,3 +1,4 @@
+import { FunctionTarget } from "..";
 import { HttpMethod, createPath } from "../utils";
 
 /**
@@ -10,8 +11,7 @@ export function Put(path?: string) {
   if (path && typeof path !== "string")
     throw new Error("Path must be a string");
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return function (target: any, key: string) {
+  return function (target: FunctionTarget, key: string) {
     if (!target) return;
     if (!target[key]) return;
     if (typeof target[key] !== "function")

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,7 @@
 import "reflect-metadata";
 
 import { Server, Serve as BunServe, Errorlike } from "bun";
-import {
-  Config,
-  Controller,
-  Group,
-  Handler,
-  IkariServer,
-  Route,
-} from "./types";
+import { Config, Controller, Group, IkariServer, Route } from "./types";
 import { ServeValidator } from "./serve-validator";
 import { Context, Routes } from "./context";
 import { HttpMethod, StatusCode, createPath, startupMessage } from "./utils";
@@ -242,7 +235,7 @@ function getRoutesFromGroups(config: Config, groups: Group[]): Route[] {
             if (prefix) routePath = prefix + routePath;
             if (config.prefix) routePath = config.prefix + routePath;
             if (middlewares) {
-              routeBefore = [...(middlewares as Handler[]), ...route.before];
+              routeBefore = [...middlewares, ...route.before];
             }
 
             return { ...route, path: routePath, before: routeBefore } as Route;

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,16 +4,17 @@ import { Context } from "./context";
 
 export type LiteralUnionStr<T extends U, U = string> = T | (string & object);
 
-export type FunctionTarget = {
-  [key: string]: Handler;
-};
+// It is not possible to get the generic type of a function in TypeScript.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type FunctionTarget = any;
 
 export type Controller = {
-  prototype: FunctionTarget;
   name: string;
   length: number;
   new (...args: unknown[]): unknown;
 };
+
+export type ClassConstructor<T = object> = new (...args: unknown[]) => T;
 
 export type Route = {
   path: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,9 +8,9 @@ export type LiteralUnionStr<T extends U, U = string> = T | (string & object);
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type FunctionTarget = any;
 
-export type Controller = ClassConstructor;
+export type Controller = Constructor;
 
-export type ClassConstructor<T = object> = new (...args: unknown[]) => T;
+export type Constructor<T = object> = new (...args: unknown[]) => T;
 
 export type Route = {
   path: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,10 +4,12 @@ import { Context } from "./context";
 
 export type LiteralUnionStr<T extends U, U = string> = T | (string & object);
 
+export type FunctionTarget = {
+  [key: string]: Handler;
+};
+
 export type Controller = {
-  prototype: {
-    [key: string]: Handler;
-  };
+  prototype: FunctionTarget;
   name: string;
   length: number;
   new (...args: unknown[]): unknown;

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,8 +5,14 @@ import { Context } from "./context";
 // eslint-disable-next-line @typescript-eslint/ban-types
 export type LiteralUnionStr<T extends U, U = string> = T | (string & {});
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/ban-types
-export type Controller = {} & { prototype: any; name: string; length: number, new(...args: any[]): any };
+export type Controller = {
+  prototype: {
+    [key: string]: Handler;
+  };
+  name: string;
+  length: number;
+  new (...args: unknown[]): unknown;
+};
 
 export type Route = {
   path: string;
@@ -14,8 +20,8 @@ export type Route = {
   method: string;
   target: Controller;
   pathHasParams: boolean;
-  before: Handler[];
-  after: Handler[];
+  before: Handlers;
+  after: Handlers;
 };
 
 export interface Group {
@@ -32,7 +38,7 @@ export interface Group {
    * @example
    * middlewares: [AuthMiddleware()]
    */
-  middlewares?: Handler[];
+  middlewares?: Handlers;
   /**
    * Controller classes to be used in the group
    */
@@ -42,6 +48,8 @@ export interface Group {
 export type Handler = (
   ctx: Context
 ) => Context | Promise<Context> | void | Promise<void>;
+
+export type Handlers = Handler[];
 
 export type ErrorHandler = (err: Errorlike) => Response | Promise<Response>;
 
@@ -76,7 +84,7 @@ export type Config = {
    * @example
    * middlewares: [CORSMiddleware()]
    */
-  middlewares?: Handler[];
+  middlewares?: Handlers;
   /**
    * Serve options for the server. See Bun ServeOptions for more information.
    * @default ServeOptions

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,11 +8,7 @@ export type LiteralUnionStr<T extends U, U = string> = T | (string & object);
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type FunctionTarget = any;
 
-export type Controller = {
-  name: string;
-  length: number;
-  new (...args: unknown[]): unknown;
-};
+export type Controller = ClassConstructor;
 
 export type ClassConstructor<T = object> = new (...args: unknown[]) => T;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,8 +2,7 @@ import { Server, ServeOptions, TLSServeOptions, Errorlike } from "bun";
 
 import { Context } from "./context";
 
-// eslint-disable-next-line @typescript-eslint/ban-types
-export type LiteralUnionStr<T extends U, U = string> = T | (string & {});
+export type LiteralUnionStr<T extends U, U = string> = T | (string & object);
 
 export type Controller = {
   prototype: {


### PR DESCRIPTION
- Any usage is removed in the app.
- Used concat instead of spreading for handlers concatenation. 